### PR TITLE
Fix Pan Icon Missing and Null Error

### DIFF
--- a/UIInfoSuiteRW/Features/ShowToolUpgradeStatus.cs
+++ b/UIInfoSuiteRW/Features/ShowToolUpgradeStatus.cs
@@ -27,6 +27,7 @@ namespace UIInfoSuiteRW.Features
           or Pickaxe
           or Hoe
           or WateringCan
+          or Pan
           or GenericTool { IndexOfMenuItemView: >= 13 and <= 16 })
       {
         ParsedItemData? itemData = ItemRegistry.GetDataOrErrorItem(toolBeingUpgraded.QualifiedItemId);
@@ -105,7 +106,7 @@ namespace UIInfoSuiteRW.Features
 
     private void OnRenderingHud(object? sender, RenderingHudEventArgs e)
     {
-      if (!UIElementUtils.IsRenderingNormally() || _toolBeingUpgraded.Value == null)
+      if (!UIElementUtils.IsRenderingNormally() || _toolBeingUpgraded.Value == null || _toolUpgradeIcon.Value == null)
       {
         return;
       }
@@ -120,7 +121,7 @@ namespace UIInfoSuiteRW.Features
     private void OnRenderedHud(object? sender, RenderedHudEventArgs e)
     {
       // Show text on hover
-      if (_toolBeingUpgraded.Value != null && _toolUpgradeIcon.Value.containsPoint(Game1.getMouseX(), Game1.getMouseY()))
+      if (_toolBeingUpgraded.Value != null && _toolUpgradeIcon.Value != null && _toolUpgradeIcon.Value.containsPoint(Game1.getMouseX(), Game1.getMouseY()))
       {
         IClickableMenu.drawHoverText(Game1.spriteBatch, _hoverText.Value, Game1.dialogueFont);
       }


### PR DESCRIPTION
Fixes the calls to, _toolUpgradeIcon.Value throwing a null reference for future added tools exception while also adding the Pan icon.

Shamelessly took this from the PR of UI Info Suite 2. https://github.com/Annosz/UIInfoSuite2/pull/597